### PR TITLE
Fix fix_jetson_docker.sh execution error

### DIFF
--- a/scripts/fix_jetson_docker.sh
+++ b/scripts/fix_jetson_docker.sh
@@ -21,6 +21,7 @@
 
 main()
 {
+    SCRIPTS_DIR=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
     local PLATFORM="$(uname -m)"
     # Check if is running on NVIDIA Jetson platform
     if [[ $PLATFORM != "aarch64" ]]; then
@@ -28,25 +29,27 @@ main()
         exit 33
     fi
 
-    read -p "Do you wish to fix docker to works with isaac-ros? [Y/n] " yn
-        case $yn in
-            [Yy]* ) # Break and install jetson_stats 
-                    break;;
-            [Nn]* ) exit;;
-        * ) echo "Please answer yes or no.";;
-    esac
+    while :; do
+        read -p "Do you wish to fix docker to works with isaac-ros? [Y/n] " yn
+            case $yn in
+                [Yy]* ) # Break and install jetson_stats
+                        break;;
+                [Nn]* ) exit;;
+            * ) echo "Please answer yes or no.";;
+        esac
+    done
 
     # Make sure the nvidia docker runtime will be used for builds
     DEFAULT_RUNTIME=$(docker info | grep "Default Runtime: nvidia" ; true)
     if [[ -z "$DEFAULT_RUNTIME" ]]; then
         echo "${yellow} - Set runtime nvidia on /etc/docker/daemon.json${reset}"
         sudo mv /etc/docker/daemon.json /etc/docker/daemon.json.bkp
-        sudo cp docker-config/daemon.json /etc/docker/daemon.json
+        sudo cp ${SCRIPTS_DIR}/docker-config/daemon.json /etc/docker/daemon.json
     fi
 
     local PATH_HOST_FILES4CONTAINER="/etc/nvidia-container-runtime/host-files-for-container.d"
     echo "${green} - Enable dockers to build jetson_multimedia api folder${reset}"
-    sudo cp docker-config/jetson_multimedia_api.csv $PATH_HOST_FILES4CONTAINER/jetson_multimedia_api.csv
+    sudo cp ${SCRIPTS_DIR}/docker-config/jetson_multimedia_api.csv $PATH_HOST_FILES4CONTAINER/jetson_multimedia_api.csv
 
     echo "${yellow} - Restart docker server${reset}"
     sudo systemctl restart docker.service


### PR DESCRIPTION
The current docker config update script gives the following error when run as per the [scripts/README.md](https://github.com/rbonghi/isaac_ros_tutorial/blob/main/scripts/README.md).

```
$ bash ./scripts/fix_jetson_docker.sh 
Do you wish to fix docker to works with isaac-ros? [Y/n] y
./scripts/fix_jetson_docker.sh: line 34: break: only meaningful in a `for', `while', or `until' loop
 - Enable dockers to build jetson_multimedia api folder
cp: cannot stat 'docker-config/jetson_multimedia_api.csv': No such file or directory
 - Restart docker server
```

This PR fixes the above error.

```
$ bash ./scripts/fix_jetson_docker.sh 
Do you wish to fix docker to works with isaac-ros? [Y/n] q
Please answer yes or no.
Do you wish to fix docker to works with isaac-ros? [Y/n] q
Please answer yes or no.
Do you wish to fix docker to works with isaac-ros? [Y/n] yes
 - Enable dockers to build jetson_multimedia api folder
 - Restart docker server
```

## Environment

Jetson Nano + JetPack 4.5.1 + rbonghi/isaac_ros_tutorial (ec1a40a3b96c8170c8e5f7ba6d2906822861a054)

```
$ pwd
/home/jetson/isaac_ros_tutorial
$ git log | head -n1
commit ec1a40a3b96c8170c8e5f7ba6d2906822861a054
```

## To Reproduce

1. Install JetPack (I tried with JetPack 4.5.1)
2. Run `git clone https://github.com/rbonghi/isaac_ros_tutorial.git`
3. Run `cd ~/isaac_ros_tutorial && bash ./scripts/fix_jetson_docker.sh`


