### PR TITLE
Fix symbol lookup error while executing image_saver

### DIFF
--- a/00-isaac_ros_base/Dockerfile
+++ b/00-isaac_ros_base/Dockerfile
@@ -90,9 +90,11 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 RUN . /opt/ros/$ROS_DISTRO/install/setup.sh && \
     cd ${ROS_ROOT} && \
-    rosdep install -y --ignore-src --from-paths src --rosdistro foxy && \
+    rosdep install -y --ignore-src --from-paths src --rosdistro foxy \
+    --skip-keys "libopencv-dev libopencv-contrib-dev libopencv-imgproc-dev python-opencv python3-opencv" && \
     colcon build --merge-install --packages-up-to pcl_conversions sensor_msgs_py diagnostic_updater xacro \
-    camera_calibration_parsers image_transport image_common camera_info_manager && \
+    camera_calibration_parsers image_transport image_common camera_info_manager \
+    image_publisher depth_image_proc image_proc image_view image_rotate stereo_image_proc compressed_image_transport compressed_depth_image_transport && \
     rm -Rf src logs build
 
 # Install gcc8 for cross-compiled binaries from Ubuntu 20.04

--- a/00-isaac_ros_base/isaac_ros_base.rosinstall
+++ b/00-isaac_ros_base/isaac_ros_base.rosinstall
@@ -21,3 +21,35 @@
     local-name: image_common
     version: 3.0.0
     uri: https://github.com/ros-perception/image_common.git
+- git:
+    local-name: image_pipeline/image_publisher
+    uri: https://github.com/ros2-gbp/image_pipeline-release.git
+    version: release/foxy/image_publisher/2.2.1-1
+- git:
+    local-name: image_pipeline/depth_image_proc
+    uri: https://github.com/ros2-gbp/image_pipeline-release.git
+    version: release/foxy/depth_image_proc/2.2.1-1
+- git:
+    local-name: image_pipeline/image_proc
+    uri: https://github.com/ros2-gbp/image_pipeline-release.git
+    version: release/foxy/image_proc/2.2.1-1
+- git:
+    local-name: image_pipeline/image_view
+    uri: https://github.com/ros2-gbp/image_pipeline-release.git
+    version: release/foxy/image_view/2.2.1-1
+- git:
+    local-name: image_pipeline/image_rotate
+    uri: https://github.com/ros2-gbp/image_pipeline-release.git
+    version: release/foxy/image_rotate/2.2.1-1
+- git:
+    local-name: image_pipeline/stereo_image_proc
+    uri: https://github.com/ros2-gbp/image_pipeline-release.git
+    version: release/foxy/stereo_image_proc/2.2.1-1
+- git:
+    local-name: image_transport_plugins/compressed_image_transport
+    uri: https://github.com/ros2-gbp/image_transport_plugins-release.git
+    version: release/foxy/compressed_image_transport/2.3.1-1
+- git:
+    local-name: image_transport_plugins/compressed_depth_image_transport
+    uri: https://github.com/ros2-gbp/image_transport_plugins-release.git
+    version: release/foxy/compressed_depth_image_transport/2.3.1-1


### PR DESCRIPTION
This PR fixes the Docker image which shows `symbol lookup error` executing `image_saver` node.

Addressed in https://github.com/rbonghi/isaac_ros_tutorial/issues/4.